### PR TITLE
Move tip section outside CardDescription in Register

### DIFF
--- a/client/pages/Register.tsx
+++ b/client/pages/Register.tsx
@@ -156,17 +156,17 @@ export default function Register() {
             <CardTitle className="text-2xl text-center">Criar Conta</CardTitle>
             <CardDescription className="text-center">
               Preencha as informações para criar sua conta
-              <div className="mt-3 p-3 bg-green-50 dark:bg-green-950/30 rounded-lg text-xs text-green-700 dark:text-green-300">
-                <p className="font-medium mb-1">💡 Dica:</p>
-                <p>
-                  Após criar sua conta, você poderá fazer login usando suas
-                  credenciais.
-                </p>
-                <p>
-                  Para teste imediato, use as contas demo na página de login.
-                </p>
-              </div>
             </CardDescription>
+            <div className="mt-3 p-3 bg-green-50 dark:bg-green-950/30 rounded-lg text-xs text-green-700 dark:text-green-300">
+              <div className="font-medium mb-1">💡 Dica:</div>
+              <div>
+                Após criar sua conta, você poderá fazer login usando suas
+                credenciais.
+              </div>
+              <div>
+                Para teste imediato, use as contas demo na página de login.
+              </div>
+            </div>
           </CardHeader>
           <CardContent className="space-y-4">
             <form onSubmit={handleSubmit} className="space-y-4">


### PR DESCRIPTION
## Changes Made

### Layout Restructuring
- Moved the tip section (green info box) from inside `CardDescription` to outside, placing it as a sibling component within `CardHeader`
- Changed HTML structure from `<p>` tags to `<div>` tags for the tip content elements

### Specific Modifications
- Relocated the entire tip container (`bg-green-50 dark:bg-green-950/30`) from being nested within `CardDescription` 
- Updated the tip title from `<p className="font-medium mb-1">💡 Dica:</p>` to `<div className="font-medium mb-1">💡 Dica:</div>`
- Changed tip content paragraphs from `<p>` elements to `<div>` elements
- Maintained all existing styling classes and content text

The tip section now appears as a separate component after the card description rather than being embedded within it.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ec805c58647f4d70849abc3822a58cb8/pixel-space)

👀 [Preview Link](https://ec805c58647f4d70849abc3822a58cb8-pixel-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ec805c58647f4d70849abc3822a58cb8</projectId>-->
<!--<branchName>pixel-space</branchName>-->